### PR TITLE
Issues/gras 1334 editable content type

### DIFF
--- a/app/views/contentTypeDetail/contentTypeDetailViewModel.js
+++ b/app/views/contentTypeDetail/contentTypeDetailViewModel.js
@@ -29,14 +29,21 @@ define(['grasshopperModel', 'resources', 'constants', 'masseuse', 'plugins', 'un
     function validate(attrs) {
         var err;
 
+
         if(_.isEmpty(attrs.label)) {
             err = resources.contentType.validation.mustHaveLabel;
         }
 
         if(!err) {
             _.each(attrs.fields, function(field) {
-                if(_.isEmpty(field.label)) {
+                if(_.isEmpty(field.label)) { // field name presence
                     err = resources.contentType.validation.fieldsMustHaveLabel;
+                }
+                if(_.isEmpty(field._id)) { // field id presence
+                    err = resources.contentType.validation.fieldsMustHaveIds;
+                }
+                if(_.where(attrs.fields, {_id: field._id}).length > 1) { // uniqueness
+                    err = resources.contentType.validation.fieldsMustBeUnique;
                 }
             });
         }


### PR DESCRIPTION
Should fix GRAS-1334: The ID of a content type field should be editable and add a couple of new validaions for content-types
