### PR TITLE
Bumped Foundation version number

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "grasshopper-admin",
   "dependencies": {
-    "foundation": "5.0.2",
+    "foundation": "5.5.2",
     "requirejs-text": "2.0.10",
     "js-base64": "2.1.2",
     "masseuse": "2.3.0",


### PR DESCRIPTION
Foundation's scss `exports` mixin contained error which were preventing from proper compiling of some elements.

This version fixes that and Grasshopper Admin looks fine now.
